### PR TITLE
Add JSON filter

### DIFF
--- a/app/templates/_base.html
+++ b/app/templates/_base.html
@@ -21,7 +21,7 @@
 <script src="node_modules/jquery/dist/jquery.js" type="text/javascript"></script>
 <script src="scripts/libs/jquery-ui-1.10.2.custom.min.js" type="text/javascript"></script>
 <script>
- // var inmates = {{ INMATES }};
+ // var inmates = {{ INMATES|json }};
 </script>
 <script src="scripts/libs/filter.js" type="text/javascript"></script>
 <script src="assets/inmates.js" type="text/javascript"></script>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,8 +6,7 @@ var fs = require('fs');
 var gulp = require('gulp');
 var $ = require('gulp-load-plugins')({
   rename: {
-    'gulp-ruby-sass': 'sass',
-    'gulp-nunjucks-render': 'nunjucks'
+    'gulp-ruby-sass': 'sass'
   }
 });
 var runSequence = require('run-sequence');
@@ -59,10 +58,14 @@ gulp.task('templates', function() {
   data.SITE = packageData.config;
 
   // disable watching or it'll hang forever
-  nunjucks.configure('app', {watch: false});
+  var env = nunjucks.configure('app', {watch: false});
+
+  env.addFilter('json', function(obj) {
+    return JSON.stringify(obj);
+  });
 
   var nunjuckified = map(function(code, filename) {
-    return nunjucks.renderString(code.toString(), data);
+    return env.renderString(code.toString(), data);
   });
 
   return gulp.src(['app/**/{*,!_*}.html', '!app/**/_*.html'])


### PR DESCRIPTION
Adds our own custom filter to `nunjucks` so you can convert the JSON you're passing in with the template.

However – I am going to make a suggestion. That's a really big file to be loading in as JSON just to build HTML. You should try and build it with Nunjucks itself. You have access to the actual HTML – take advantage of that!

Everything this is doing:

``` html
  <script id="inmate-template" type="text/html">
    <div class="col-span-4 inmate">
      <div class="thumbnail">
        <span class="label label-success rating"></span>
        <div class="caption">
          <h4 class="name"><%= first_name %> <%= last_name %></h4>
          <h4 class="race">Race: <%= race %></h4>
          <h4 class="age">Age: <%= age %></h4>
          <h4 class="timeserved">Time on Death Row: <%= time_served %></h4>
          <div class="outline">
            <%= summary %>
          </div>
        </div>
      </div>
  </div>
  </script>
```

Could move over to Nunjucks. That may futz a little with `filter.js`, but there are some pretty big optimizations we can work into this later if we go that route.
